### PR TITLE
chore(tools): bump FsSemanticTagger 0.12.0-alpha.5 and CoverageRatchet 0.13.0-alpha.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "coverageratchet": {
-      "version": "0.13.0-alpha.2",
+      "version": "0.13.0-alpha.3",
       "commands": [
         "coverageratchet"
       ],
@@ -38,7 +38,7 @@
       "rollForward": false
     },
     "fssemantictagger": {
-      "version": "0.12.0-alpha.4",
+      "version": "0.12.0-alpha.5",
       "commands": [
         "fssemantictagger"
       ],

--- a/mise.toml
+++ b/mise.toml
@@ -115,6 +115,11 @@ description = "Create a release with semantic version tagging"
 run = "dotnet tool run fssemantictagger release"
 depends = ["ci"]
 
+[tasks.release-dry-run]
+description = "Preview a release without mutating (no tag, no publish)"
+run = "dotnet tool run fssemantictagger release --dry-run"
+depends = ["build"]
+
 [tasks.release-alpha]
 description = "Create an alpha pre-release"
 run = "dotnet tool run fssemantictagger alpha"


### PR DESCRIPTION
## Summary
- Bump `fssemantictagger` 0.12.0-alpha.4 → 0.12.0-alpha.5 (adds `--dry-run`; CLI flags now named — this repo already uses the flagless forms so no migration needed)
- Bump `coverageratchet` 0.13.0-alpha.2 → 0.13.0-alpha.3 (internal + bug fixes)
- Add mise task `release-dry-run` for previewing a release without mutating

## Test plan
- [ ] `dotnet tool restore` succeeds (both package versions now indexed on NuGet)
- [ ] `mise run release-dry-run` previews a release without creating a tag